### PR TITLE
chore(phpcbf): set PHP version to 7.2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,6 +24,6 @@ jobs:
         run: |
           set -x +e
           rc=0
-          vendor/bin/phpcbf --colors .; ((rc+=$?))
+          vendor/bin/phpcbf --runtime-set php_version 70200 --colors .; ((rc+=$?))
           git diff --color --exit-code; ((rc+=$?))
           ((rc==0))

--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -9,4 +9,4 @@ pre-commit:
       exclude:
         - vendor/*
       run: |
-        vendor/bin/phpcbf {staged_files}
+        vendor/bin/phpcbf --runtime-set php_version 70200 {staged_files}


### PR DESCRIPTION
7.2 is currently documented as minimum version Blesta supports.

Does not look like this can be set in phpcs.xml, nor does it cause any formatting changes at time of writing.

Refs https://github.com/UpCloudLtd/upcloud-blesta-module/pull/1#discussion_r2013650362