### PR TITLE
refactor: rename top level module to just upcloud

### DIFF
--- a/upcloud.php
+++ b/upcloud.php
@@ -2,7 +2,7 @@
 
 use Blesta\Core\Util\Validate\Server;
 
-class Upcloudvps extends Module
+class Upcloud extends Module
 {
     public function __construct()
     {


### PR DESCRIPTION
Follows conventions set by various other similar modules.