### PR TITLE
style: use shorthand array syntax

### DIFF
--- a/apis/upcloudvps_api.php
+++ b/apis/upcloudvps_api.php
@@ -170,7 +170,7 @@ class UpcloudvpsApi
 
     public function serverOperation($action, $ServerUUID, $stop_type = null)
     {
-        $data = array();
+        $data = [];
         if ($stop_type !== null) {
             $data[$action . '_server']['stop_type'] = $stop_type;
             $data[$action . '_server']['timeout'] = "60";
@@ -289,18 +289,18 @@ class UpcloudvpsApi
         if (!($this->GetIPaddress($IP)['response']['ip_address']['server'] == $instanceId)) {
             $this->logger->error('IP does not belong to your server');
         }
-        return $this->put('ip_address/' . $IP, array('ip_address' => array('ptr_record' => $ptr_record)));
+        return $this->put('ip_address/' . $IP, ['ip_address' => ['ptr_record' => $ptr_record]]);
     }
 
 
     public function vncPasswordUpdate($instanceId, $vncPass)
     {
-        return $this->put('server/' . $instanceId, array('server' => array('remote_access_password' => $vncPass)));
+        return $this->put('server/' . $instanceId, ['server' => ['remote_access_password' => $vncPass]]);
     }
 
     public function vncEnableDisable($instanceId, $vncType)
     {
-        return $this->put('server/' . $instanceId, array('server' => array('remote_access_enabled' => $vncType)));
+        return $this->put('server/' . $instanceId, ['server' => ['remote_access_enabled' => $vncType]]);
     }
 
     public function modifyVPS($instanceId, $serverConfig)

--- a/upcloud.php
+++ b/upcloud.php
@@ -427,11 +427,11 @@ class Upcloud extends Module
             $actionResponse = $api->$actionName($vmId);
             $success = true;
             if ($expectedResponseCode && $actionResponse['response_code'] !== $expectedResponseCode) {
-                $this->Input->setErrors(array('api' => array('response' => $actionResponse['response']['error']['error_message'])));
+                $this->Input->setErrors(['api' => ['response' => $actionResponse['response']['error']['error_message']]]);
                 $success = false;
             }
             if ($actionResponse['error']['error_message']) {
-                $this->Input->setErrors(array('api' => array('response' => $actionResponse['error']['error_message'])));
+                $this->Input->setErrors(['api' => ['response' => $actionResponse['error']['error_message']]]);
                 $success = false;
             }
             $this->log($logTag, serialize($actionResponse), 'output', $success);
@@ -950,7 +950,7 @@ class Upcloud extends Module
                     break;
             }
             if ($action['error']['error_message']) {
-                $this->Input->setErrors(array('api' => array('response' => $action['error']['error_message'])));
+                $this->Input->setErrors(['api' => ['response' => $action['error']['error_message']]]);
             }
           //      $this->log('upcloud|action', serialize($action), 'output', true);
         }
@@ -1067,7 +1067,7 @@ class Upcloud extends Module
                 $service_fields = $this->serviceFieldsToObject($service->fields);
                 $action = $api->ModifyServer($service_fields->upcloudvps_vmid, $package_to->meta->server_plan);
                 if ($action['response']['error']['error_message']) {
-                    $this->Input->setErrors(array('api' => array('response' => $action['response']['error']['error_message'])));
+                    $this->Input->setErrors(['api' => ['response' => $action['response']['error']['error_message']]]);
                 }
             }
         }


### PR DESCRIPTION
Blesta guidelines do not have an explicit note about this, but the style guide's examples use the shorthand form.