### PR TITLE
feat: switch module to semantic versioning

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "2024.1",
+    "version": "1.0.0",
     "name": "Upcloudvps.name",
     "description": "Upcloudvps.description",
     "authors": [


### PR DESCRIPTION
Per https://docs.blesta.com/display/dev/Module+Configuration#ModuleConfiguration-Definition
> This should be a semantic version number.