### PR TITLE
refactor: rename methods to camelCase, classes to PascalCase

### DIFF
--- a/apis/upcloudvps_api.php
+++ b/apis/upcloudvps_api.php
@@ -2,7 +2,7 @@
 
 use Blesta\Core\Util\Common\Traits\Container;
 
-class UpcloudvpsApi
+class UpcloudVpsApi
 {
     use Container;
 
@@ -149,7 +149,7 @@ class UpcloudvpsApi
      *
      * @return array The API response
      */
-    public function GetAccountInfo()
+    public function getAccountInfo()
     {
         return $this->get('account');
     }
@@ -159,7 +159,7 @@ class UpcloudvpsApi
      *
      * @return array The API response
      */
-    public function GetPrices()
+    public function getPrices()
     {
         return $this->get('price');
     }
@@ -169,7 +169,7 @@ class UpcloudvpsApi
      *
      * @return array The API response
      */
-    public function GetZones()
+    public function getZones()
     {
         return $this->get('zone');
     }
@@ -179,7 +179,7 @@ class UpcloudvpsApi
      *
      * @return array The API response
      */
-    public function GetTimezones()
+    public function getTimezones()
     {
         return $this->get('timezone');
     }
@@ -189,7 +189,7 @@ class UpcloudvpsApi
      *
      * @return array The API response
      */
-    public function GetPlans()
+    public function getPlans()
     {
         return $this->get('plan');
     }
@@ -199,7 +199,7 @@ class UpcloudvpsApi
      *
      * @return array The API response
      */
-    public function GetServerConfigurations()
+    public function getServerConfigurations()
     {
         return $this->get('server_size');
     }
@@ -209,7 +209,7 @@ class UpcloudvpsApi
      *
      * @return array The API response
      */
-    public function GetAllServers()
+    public function getAllServers()
     {
         return $this->get('server');
     }
@@ -220,7 +220,7 @@ class UpcloudvpsApi
      * @param string $ServerUUID The UUID of the server
      * @return array The API response
      */
-    public function GetServer($ServerUUID)
+    public function getServer($ServerUUID)
     {
         return $this->get('server/' . rawurlencode($ServerUUID));
     }
@@ -230,7 +230,7 @@ class UpcloudvpsApi
      *
      * @return array The API response
      */
-    public function GetTemplate()
+    public function getTemplate()
     {
         return $this->get('storage/template');
     }
@@ -245,9 +245,9 @@ class UpcloudvpsApi
      *  - template (string) The template UUID
      * @return array The API response
      */
-    public function CreateServer($params)
+    public function createServer($params)
     {
-        $Templates = $this->GetTemplate()['response']['storages']['storage'];
+        $Templates = $this->getTemplate()['response']['storages']['storage'];
         foreach ($Templates as $Template) {
             if ($Template['uuid'] == $params['template']) {
                 $TemplateTitle = $Template['title'];
@@ -255,7 +255,7 @@ class UpcloudvpsApi
                 break;
             }
         }
-        $AllPlans = $this->Getplans()['response']['plans']['plan'];
+        $AllPlans = $this->getPlans()['response']['plans']['plan'];
         foreach ($AllPlans as $Plans) {
             if ($Plans['name'] == $params['plan']) {
                 $PlanName = $Plans['name'];
@@ -271,7 +271,7 @@ class UpcloudvpsApi
                 'zone' => $params['zone'], // GetZones()
                 'title' => $params['title'], // hostname
                 'hostname' => $params['title'], // hostname
-                'plan' => $PlanName, // Getplans()
+                'plan' => $PlanName, // getPlans()
                 //  "simple_backup" => "0430,weeklies",
                 'remote_access_enabled' => 'yes',
                 'storage_devices' => [
@@ -279,8 +279,8 @@ class UpcloudvpsApi
                         [
                             'action' => 'clone',
                             'storage' => $TemplateUUID, // GetTemplates()
-                            'size' => $PlanSize, // storage_size from Getplans()
-                            'tier' => $PlanTier, // storage_tier from Getplans()
+                            'size' => $PlanSize, // storage_size from getPlans()
+                            'tier' => $PlanTier, // storage_tier from getPlans()
                             'title' => $TemplateTitle, // OS Name
                         ]
                     ]
@@ -315,7 +315,7 @@ class UpcloudvpsApi
      * @param string $ServerUUID The UUID of the server
      * @return array The API response
      */
-    public function StartServer($ServerUUID)
+    public function startServer($ServerUUID)
     {
         return $this->serverOperation('start', $ServerUUID);
     }
@@ -326,7 +326,7 @@ class UpcloudvpsApi
      * @param string $ServerUUID The UUID of the server
      * @return array The API response
      */
-    public function StopServer($ServerUUID)
+    public function stopServer($ServerUUID)
     {
         return $this->serverOperation('stop', $ServerUUID, 'hard');
     }
@@ -337,7 +337,7 @@ class UpcloudvpsApi
      * @param string $ServerUUID The UUID of the server
      * @return array The API response
      */
-    public function RestartServer($ServerUUID)
+    public function restartServer($ServerUUID)
     {
         return $this->serverOperation('restart', $ServerUUID, 'hard');
     }
@@ -348,7 +348,7 @@ class UpcloudvpsApi
      * @param string $ServerUUID The UUID of the server
      * @return array The API response
      */
-    public function CancelServer($ServerUUID)
+    public function cancelServer($ServerUUID)
     {
         return $this->serverOperation('cancel', $ServerUUID);
     }
@@ -359,7 +359,7 @@ class UpcloudvpsApi
      * @param string $ServerUUID The UUID of the server
      * @return array The API response
      */
-    public function DeleteServer($ServerUUID)
+    public function deleteServer($ServerUUID)
     {
         return $this->delete('server/' . rawurlencode($ServerUUID));
     }
@@ -372,10 +372,10 @@ class UpcloudvpsApi
      * @param string $Plan The name of the target plan
      * @return array The API response from the final operation (storage resize or plan change)
      */
-    public function ModifyServer($uuid, $Plan)
+    public function modifyServer($uuid, $Plan)
     {
         $this->stopServerAndWait($uuid);
-        $allPlans = $this->Getplans()['response']['plans']['plan'];
+        $allPlans = $this->getPlans()['response']['plans']['plan'];
         foreach ($allPlans as $plan) {
             if ($plan['name'] == $Plan) {
                 $planSize = $plan['storage_size'];
@@ -387,7 +387,7 @@ class UpcloudvpsApi
         if ($upgradePlan['response']['error']['error_message']) {
             return $upgradePlan;
         } else {
-            $storages = $this->GetServer($uuid)['response']['server']['storage_devices']['storage_device'];
+            $storages = $this->getServer($uuid)['response']['server']['storage_devices']['storage_device'];
             foreach ($storages as $storage) {
                 if ($storage['part_of_plan'] == "yes") {
                     $storageId = $storage['storage'];
@@ -397,7 +397,7 @@ class UpcloudvpsApi
             }
             if ($storageId && $planSize > $existingStorageSize) {
                 $modeyStorage = $this->modifyStorage($storageId, $planSize);
-                $this->StartServer($uuid);
+                $this->startServer($uuid);
                 return $modeyStorage;
             }
         }
@@ -428,7 +428,7 @@ class UpcloudvpsApi
      * @param string $ServerUUID The UUID of the server
      * @return array The API response from the delete operation
      */
-    public function DeleteServerAndStorage($ServerUUID)
+    public function deleteServerAndStorage($ServerUUID)
     {
         $this->stopServerAndWait($ServerUUID);
         return $this->delete(sprintf('server/%s?storages=1', rawurlencode($ServerUUID)));
@@ -441,7 +441,7 @@ class UpcloudvpsApi
      * @param string $ServerUUID The UUID of the server
      * @return array The API response from the delete operation
      */
-    public function DeleteServerAndStorageAndBackups($ServerUUID)
+    public function deleteServerAndStorageAndBackups($ServerUUID)
     {
         $this->stopServerAndWait($ServerUUID);
         return $this->delete(sprintf('server/%s?storages=1&backups=delete', rawurlencode($ServerUUID)));
@@ -454,17 +454,17 @@ class UpcloudvpsApi
      */
     public function stopServerAndWait($ServerUUID)
     {
-        $result = $this->GetServer($ServerUUID);
+        $result = $this->getServer($ServerUUID);
         $state = $result['response']['server']['state'];
         if ($state == 'started') {
-            $this->StopServer($ServerUUID);
+            $this->stopServer($ServerUUID);
         }
 
         $times = 0;
         // If VM delete takes time please increase it but when tested working within 45 second
         while ($state != 'stopped' && $times < 45) {
             sleep(2);
-            $result = $this->GetServer($ServerUUID);
+            $result = $this->getServer($ServerUUID);
             $state = $result['response']['server']['state'];
             ++$times;
         }
@@ -480,7 +480,7 @@ class UpcloudvpsApi
      * @param string $IPAddress The IP address
      * @return array The API response
      */
-    public function GetIPaddress($IPAddress)
+    public function getIpAddress($IPAddress)
     {
         return $this->get('ip_address/' . rawurlencode($IPAddress));
     }
@@ -493,9 +493,9 @@ class UpcloudvpsApi
      * @param string $ptr_record The new PTR record value
      * @return array The API response
      */
-    public function ModifyIPaddress($instanceId, $IP, $ptr_record)
+    public function modifyIpAddress($instanceId, $IP, $ptr_record)
     {
-        if (!($this->GetIPaddress($IP)['response']['ip_address']['server'] == $instanceId)) {
+        if (!($this->getIpAddress($IP)['response']['ip_address']['server'] == $instanceId)) {
             $this->logger->error('IP does not belong to your server');
         }
         return $this->put('ip_address/' . rawurlencode($IP), ['ip_address' => ['ptr_record' => $ptr_record]]);
@@ -533,7 +533,7 @@ class UpcloudvpsApi
      * @param array $serverConfig An array containing server settings to modify (e.g., ['title' => 'new_title'])
      * @return array The API response
      */
-    public function modifyVPS($instanceId, $serverConfig)
+    public function modifyVps($instanceId, $serverConfig)
     {
         return $this->put('server/' . rawurlencode($instanceId), $serverConfig);
     }
@@ -544,7 +544,7 @@ class UpcloudvpsApi
      * @param int $bytes The number of bytes
      * @return float The value in GB
      */
-    public function formatSizeBytestoGB($bytes)
+    public function formatSizeBytestoGb($bytes)
     {
         return round($bytes / 1024 / 1024 / 1024, 2);
     }

--- a/upcloud.php
+++ b/upcloud.php
@@ -174,7 +174,7 @@ class Upcloud extends Module
     {
         try {
             $api = $this->getApi($api_token, $api_base_url);
-            $result = $api->GetAccountInfo();
+            $result = $api->getAccountInfo();
             $this->log('upcloud|accountRequest', serialize($result), 'input', true);
             if ($result['response_code'] == '200') {
                 return true;
@@ -185,11 +185,11 @@ class Upcloud extends Module
     }
 
     /**
-     * Initializes and returns an instance of the UpcloudvpsApi.
+     * Initializes and returns an instance of the UpcloudVpsApi.
      *
      * @param string $api_token The UpCloud API token
      * @param string $api_base_url The UpCloud API base URL (optional)
-     * @return UpcloudvpsApi An instance of the UpCloud API wrapper
+     * @return UpcloudVpsApi An instance of the UpCloud API wrapper
      */
     private function getApi($api_token, $api_base_url = null)
     {
@@ -212,7 +212,7 @@ class Upcloud extends Module
             'blestaVer' => $blestaVer,
             'moduleVer' => $this->config->version,
         ];
-        $api = new UpcloudvpsApi($params);
+        $api = new UpcloudVpsApi($params);
         return $api;
     }
 
@@ -225,8 +225,8 @@ class Upcloud extends Module
     private function getServerPlans($module_row)
     {
         $api = $this->getApi($module_row->meta->api_token, $module_row->meta->api_base_url);
-        $result = $api->Getplans()['response']['plans']['plan'];
-        //$this->log('upcloud|Getplans', serialize($result), 'input', true);
+        $result = $api->getPlans()['response']['plans']['plan'];
+        //$this->log('upcloud|getPlans', serialize($result), 'input', true);
         $Vmplans = [];
         foreach ($result as $plan) {
             $PlanDesc = Language::_('Upcloudvps.package.cpu', true) . ': ' . $plan['core_number'] . ' ' . Language::_('Upcloudvps.package.cpu', true) . ' / ' . Language::_('Upcloudvps.package.memory', true) . ': '
@@ -247,8 +247,8 @@ class Upcloud extends Module
     private function getTemplates($module_row, $package = null)
     {
         $api = $this->getApi($module_row->meta->api_token, $module_row->meta->api_base_url);
-        $result_os = $api->GetTemplate()['response']['storages']['storage'];
-        //$this->log('upcloud|GetTemplates', serialize($result_os), 'input', true);
+        $result_os = $api->getTemplate()['response']['storages']['storage'];
+        //$this->log('upcloud|getTemplates', serialize($result_os), 'input', true);
         $templates = [];
         if ($package) {
             foreach ($result_os as $os) {
@@ -275,7 +275,7 @@ class Upcloud extends Module
     private function getLocations($module_row)
     {
         $api = $this->getApi($module_row->meta->api_token, $module_row->meta->api_base_url);
-        $zones = $api->GetZones()['response']['zones']['zone'];
+        $zones = $api->getZones()['response']['zones']['zone'];
         // $this->log('upcloud|getLocations', serialize($zones), 'input', true);
         $zoneLocation = [];
         foreach ($zones as $zone) {
@@ -739,7 +739,7 @@ class Upcloud extends Module
             try {
                 $api = $this->getApi($row->meta->api_token, $row->meta->api_base_url);
                 if (empty($vars['upcloudvps_vmid'])) {
-                    $server = $api->CreateServer($params);
+                    $server = $api->createServer($params);
                     $this->log('upcloud', serialize($server), 'output', true);
                     if ($server['response_code'] != '202') {
                         $this->Input->setErrors(
@@ -1060,7 +1060,7 @@ class Upcloud extends Module
         $row = $this->getModuleRow();
         $service_fields = $this->serviceFieldsToObject($service->fields);
         $api = $this->getApi($row->meta->api_token, $row->meta->api_base_url);
-        $response = $api->GetServer($service_fields->upcloudvps_vmid)['response']['server'];
+        $response = $api->getServer($service_fields->upcloudvps_vmid)['response']['server'];
         $server_details = $response ?? (object) [];
         $this->view = new View($client ? 'client_service_info' : 'admin_service_info', 'default');
         $this->view->base_uri = $this->base_uri;
@@ -1076,7 +1076,7 @@ class Upcloud extends Module
             }
         }
 
-        $zones = $api->GetZones()['response']['zones']['zone'];
+        $zones = $api->getZones()['response']['zones']['zone'];
 
         foreach ($zones as $zone) {
             if ($zone['id'] == $server_details['zone']) {
@@ -1205,26 +1205,26 @@ class Upcloud extends Module
         $service_fields = $this->serviceFieldsToObject($service->fields);
         $templates = $this->getTemplates($row, $package);
         $api = $this->getApi($row->meta->api_token, $row->meta->api_base_url);
-        //  $this->log('upcloud|GetVMInformation', serialize($service_fields), 'input', true);
+        //  $this->log('upcloud|getTabActions', serialize($service_fields), 'input', true);
         $vmId = $service_fields->upcloudvps_vmid;
-        $server_details = $api->GetServer($vmId)['response']['server'];
+        $server_details = $api->getServer($vmId)['response']['server'];
 
         // Perform actions
         if (!empty($post['action'])) {
             switch ($post['action']) {
                 case 'restart':
-                    $action = $api->RestartServer($vmId)['response'];
+                    $action = $api->restartServer($vmId)['response'];
                     break;
                 case 'change_ptr':
                     if ($post['ip'] && $post['ptr']) {
-                        $action = $api->ModifyIPaddress($vmId, $post['ip'], $post['ptr'])['response'];
+                        $action = $api->modifyIpAddress($vmId, $post['ip'], $post['ptr'])['response'];
                     }
                     break;
                 case 'start':
-                    $action = $api->StartServer($vmId)['response'];
+                    $action = $api->startServer($vmId)['response'];
                     break;
                 case 'stop':
-                    $action = $api->StopServer($vmId)['response'];
+                    $action = $api->stopServer($vmId)['response'];
                     break;
                 case 'enblvnc':
                     $action = $api->vncEnableDisable($vmId, 'yes')['response'];
@@ -1252,7 +1252,7 @@ class Upcloud extends Module
             }
         }
 
-        $zones = $api->GetZones()['response']['zones']['zone'];
+        $zones = $api->getZones()['response']['zones']['zone'];
 
         foreach ($zones as $zone) {
             if ($zone['id'] == $server_details['zone']) {
@@ -1278,11 +1278,11 @@ class Upcloud extends Module
 
         if (!empty($server_details['networking']['interfaces']['interface'])) {
             foreach ($server_details['networking']['interfaces']['interface'] as $key => $ip) {
-                $ReverseDNSValue = $api->GetIPaddress($ip['ip_addresses']['ip_address'][0]['address'])['response'];
+                $ReverseDNSValue = $api->getIpAddress($ip['ip_addresses']['ip_address'][0]['address'])['response'];
                 if (strpos($ReverseDNSValue['ip_address']['ptr_record'], "upcloud") !== false) {
-                    $api->ModifyIPaddress($vmId, $ip['ip_addresses']['ip_address'][0]['address'], "client." . $_SERVER['SERVER_NAME'] . ".host");
+                    $api->modifyIpAddress($vmId, $ip['ip_addresses']['ip_address'][0]['address'], "client." . $_SERVER['SERVER_NAME'] . ".host");
                 }
-                $ReverseDNSValue = $api->GetIPaddress($ip['ip_addresses']['ip_address'][0]['address'])['response'];
+                $ReverseDNSValue = $api->getIpAddress($ip['ip_addresses']['ip_address'][0]['address'])['response'];
                 $server_details['networking']['interfaces']['interface'][$key]['ptr'] = $ReverseDNSValue['ip_address']['ptr_record'];
             }
         }
@@ -1295,10 +1295,10 @@ class Upcloud extends Module
             unset($server_details['remote_access_password']);
         }
 
-        foreach ($api->Getplans()['response']['plans']['plan'] as $Plan) {
+        foreach ($api->getPlans()['response']['plans']['plan'] as $Plan) {
             if ($Plan['name'] == $server_details['plan'] and $Plan['memory_amount'] == $server_details['memory_amount']) {
                 $TotalTraffic = $Plan['public_traffic_out'];
-                $Outgoing = $api->formatSizeBytestoGB($server_details['plan_ipv4_bytes'] + $server_details['plan_ipv6_bytes']);
+                $Outgoing = $api->formatSizeBytestoGb($server_details['plan_ipv4_bytes'] + $server_details['plan_ipv6_bytes']);
                 $Percentage = round((($Outgoing / $TotalTraffic) * 100), 2);
                 $progressClass = 'progress-bar-success';
                 if ($Percentage >= 49 && $Percentage < 70) {
@@ -1370,7 +1370,7 @@ class Upcloud extends Module
             $api = $this->getApi($row->meta->api_token, $row->meta->api_base_url);
             if ($package_from->meta->server_plan != $package_to->meta->server_plan) {
                 $service_fields = $this->serviceFieldsToObject($service->fields);
-                $action = $api->ModifyServer($service_fields->upcloudvps_vmid, $package_to->meta->server_plan);
+                $action = $api->modifyServer($service_fields->upcloudvps_vmid, $package_to->meta->server_plan);
                 if ($action['response']['error']['error_message']) {
                     $this->Input->setErrors(['api' => ['response' => $action['response']['error']['error_message']]]);
                 }


### PR DESCRIPTION
Per PSR-1(2). Also write acronyms as regular words which seems the current Blesta practice, as well as for PHP itself per https://wiki.php.net/rfc/class-naming-acronyms